### PR TITLE
Allow arguments to be passed to selenium

### DIFF
--- a/lib/runner/app.js
+++ b/lib/runner/app.js
@@ -2,10 +2,11 @@ var util  = require('util'),
     spawn = require('child_process').spawn,
     fs    = require('fs'),
     wd    = __dirname + '/../..',
+    args  = process.argv.slice(2), 
     selenium
           = spawn(
               'java',
-              ['-jar', __dirname + '/selenium-server-standalone-2.35.0.jar']
+              ['-jar', __dirname + '/selenium-server-standalone-2.35.0.jar'].concat(args)
             ),
     ok    = false,
     out   = fs.createWriteStream(wd + '/logs/selenium.out', {flags: 'a'}),


### PR DESCRIPTION
Arguments for selenium can be passed in as though selenium was being run directly

For example:

``` bash
selenium -role hub
```
