### PR TITLE
Propagate SIGTERM to child process.

### DIFF
--- a/lib/runner/app.js
+++ b/lib/runner/app.js
@@ -26,3 +26,8 @@ selenium.stderr.on('data', function(data) {
 
 selenium.stdout.pipe(out);
 selenium.stderr.pipe(err);
+
+process.on("SIGTERM", function () {
+	selenium.kill("SIGTERM");
+	process.exit(1);
+});


### PR DESCRIPTION
If the Selenium process is managed programmatically then the `SIGTERM` signal needs to be propagated to the child to avoid accumulating Selenium server processes. This pattern is shared with the Node [PhantomJS](https://github.com/Medium/phantomjs/blob/master/bin/phantomjs) and [ChromeDriver](https://github.com/giggio/node-chromedriver/blob/master/bin/chromedriver) wrappers as well.